### PR TITLE
A pet peeve + internal javadoc is a good idea

### DIFF
--- a/style/30_javadoc_judiciously.md
+++ b/style/30_javadoc_judiciously.md
@@ -5,6 +5,10 @@
 Javadoc can help document code but often there are better ways to do so. 
 Think carefully before deciding to write it.
 
+When you're documenting an object/method/variable, ask: What would a new developer encountering this class or method need to use it? Will that be clear to a stranger from the names and structure?
+
+Good documentation is invaluable. It enables new people to join the team, code to be reused, and it takes some of the pain out of code maintenance. But pointless documentation is actually harmful. It's a balancing act.
+
 ### Details
 
 #### Javadoc is Good
@@ -13,12 +17,25 @@ Javadoc is invaluable for external teams that must consume your code without acc
 
 All externally consumed code should have javadoc for its public methods. 
 
-Ensure that all such javadoc concentrates on *what* a method does, not *how* it does it.
+Javadoc has IDE support, which allows for easier in-flow reference than checking the source code.
+
+Readable method and variable names alone are not enough to make code self-documenting. 
+
+ - Document assumptions/requirements the code has for its inputs and the system state. 
+ - Exceptions -- what and why.
+ - When null is allowed as a parameter or may be returned, and what that means (though avoiding null is often better).
+ - In the class notes, if the object lifecycle, i.e. how this object is wired up and disposed.
+ - Simple examples to aid people learning the code.
+
+Ensure that all such javadoc concentrates on *what* a method does, not *how* it does it. 
 
 #### Javadoc is Bad
+
+The clearer you can make the code itself, the less documentation is needed. 
+
+Well chosen method and parameter names are preferable to Javadoc for ambiguous names, and there is no point in Javadoc that merely repeats information the names already convey.
 
 Javadoc duplicates information that ought to be clear from the code itself and carries a constant maintenance cost. 
 
 If it is not updated in tandem with the code then it becomes misleading.
 
-Do not Javadoc code that will be consumed and maintained only by your immediate team. Instead spend effort ensuring that the code speaks for itself.


### PR DESCRIPTION
A couple of suggested edits.
1. How many times have you seen the pointless (ofte auto-generated) javadoc that simply restates the method signature? Javadoc should say something new and helpful.
2. IMHO Javadoc makes sense for internal use too. Internal code can get used in the same way as external libraries. Code originally intended for internal use only can become an external library -- at which point much better to have written the documentation at the time. Finally, even clear well-written code can be time-consuming to decipher: when a method calls sub-methods calls sub-methods -- working out what is going on from the code alone can take time and disrupt your focus. Comments help.
