### PR TITLE
Tweaks, grammar and whitespace

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -2,19 +2,19 @@
 
 System under test
 
-#  Direct inputs     
+#  Direct inputs
 
 The inputs that a SUT directly receives via its interface (i.e method parameters)
 
-# Direct outputs    
+# Direct outputs
 
 The outputs a SUT directly returns via its interface (i.e method return values)
 
-# Indirect inputs   
+# Indirect inputs
 
 Inputs supplied to the SUT by other components with which it interacts (i.e values supplied by DOCs)
 
-# Indirect outputs  
+# Indirect outputs
 
 Outputs of the SUT that are passed to DOCs but are not visible via the SUT interface
 
@@ -22,7 +22,7 @@ Outputs of the SUT that are passed to DOCs but are not visible via the SUT inter
 
 Generic names for Dummy, Stub, Spy, Fake or Mock
 
-# Dummy            
+# Dummy
 
 Test double that is never used or called but must be present (i.e it could just be null)
 
@@ -30,15 +30,15 @@ Test double that is never used or called but must be present (i.e it could just 
 
 Test double that supplies indirect inputs to SUT (and does nothing else)
 
-# Mock              
+# Mock
 
 Test double that verifies indirect outputs from SUT (may also provide indirect input)
 
-# Spy               
+# Spy
 
 Test double that captures indirect outputs from SUT to allow later verification (may also provide indirect input)
 
-# Fake              
+# Fake
 
 Test double that acts as a lightweight stand in for some other component
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -4,11 +4,11 @@ System under test
 
 #  Direct inputs     
 
-The inputs that a SUT directly receives via it's interface (i.e method parameters)
+The inputs that a SUT directly receives via its interface (i.e method parameters)
 
 # Direct outputs    
 
-The outputs a SUT directly returns via it's interface (i.e method return values)
+The outputs a SUT directly returns via its interface (i.e method return values)
 
 # Indirect inputs   
 

--- a/specifics/100_know_how_to_implement_hashcode_and_equals.md
+++ b/specifics/100_know_how_to_implement_hashcode_and_equals.md
@@ -174,7 +174,7 @@ public int hashCode() {
 }
 ```
 
-The brevity of these implementations is attractive, but their performance is measurably poor compared to all the implementations discussed so far. If you are confident that you will pick up real performance bottlenecks with testing and profiling then using these as initial placeholder implementations may be a reasonable approach, but in general we suggest you avoid them. 
+The brevity of these implementations is attractive, but their performance is measurably poor compared to all the implementations discussed so far. If you are confident that you will not pick up real performance bottlenecks with testing and profiling then using these as initial placeholder implementations may be a reasonable approach, but in general we suggest you avoid them.
 
 ### Code Generators 
 

--- a/specifics/100_know_how_to_implement_hashcode_and_equals.md
+++ b/specifics/100_know_how_to_implement_hashcode_and_equals.md
@@ -2,23 +2,23 @@
 
 ### Summary
 
-Implementing `hashCode` and `equals` is not straightforward. Do not implement them unless it is necessary to do so. If you do implement them, make sure you know what you are doing. 
+Implementing `hashCode` and `equals` is not straightforward. Do not implement them unless it is necessary to do so. If you do implement them, make sure you know what you are doing.
 
 ### Details
 
-It is well known that if you override equals then you must also override the `hashCode` method (see Effective Java item 9). 
+It is well known that if you override equals then you must also override the `hashCode` method (see Effective Java item 9).
 
-If logically-equal objects do not have the same `hashCode` they will behave in a surprising manner if placed in a hash based collection such as `HashMap`. 
+If logically-equal objects do not have the same `hashCode` they will behave in a surprising manner if placed in a hash based collection such as `HashMap`.
 
 By "surprising", we mean your program will behave incorrectly in a fashion that is very difficult to debug.
 
-Unfortunately, implementing `equals` is surprisingly hard to do correctly. Effective Java item 8 spends about 12 pages discussing the topic.  
+Unfortunately, implementing `equals` is surprisingly hard to do correctly. Effective Java item 8 spends about 12 pages discussing the topic.
 
 The contract for equals is handily stated in the Javadoc of `java.lang.Object`. We will not repeat it here or repeat the discussion of what it means, that can be found in Effective Java and large swathes of the internet. Instead we will look at strategies for implementing it.
 
 Whichever strategy you adopt, it is important that you first write tests for your implementation.
 
-It is easy for an equals method to cause hard-to-diagnose bugs if the code changes (e.g. if fields are added or their type changes). Writing tests for equals methods used to be a painful and time-consuming procedure, but libraries now exist that make it trivial to specify the common cases (see Testing FAQs). 
+It is easy for an equals method to cause hard-to-diagnose bugs if the code changes (e.g. if fields are added or their type changes). Writing tests for equals methods used to be a painful and time-consuming procedure, but libraries now exist that make it trivial to specify the common cases (see Testing FAQs).
 
 ### Don't
 
@@ -28,7 +28,7 @@ Most classes do not need an equals method. Unless your class represents some sor
 
 An irritating gray area are classes where the production code never has a requirement to compare equality but the test code does. The dilemma here is whether to implement the methods purely for the benefit of the tests or to complicate the test code with custom equality checks.
 
-There is, of course, no right answer here; we would suggest first trying the compare-it-in-the test approach before falling back to providing a custom equals method. 
+There is, of course, no right answer here; we would suggest first trying the compare-it-in-the test approach before falling back to providing a custom equals method.
 
 The custom equality checks can be cleanly shared by implementing a custom assertion using a library such as AssertJ or Hamcrest.
 
@@ -39,7 +39,7 @@ Effective Java tentatively suggests having your class throw an error if equals i
   throw new AssertionError(); // Method is never called
 }
 ```
- 
+
 This seems like a good idea but, unfortunately, it will confuse most static analysis tools. On balance, it probably creates more problems than it solves.
 
 ### Auto-Generate With an IDE
@@ -111,7 +111,7 @@ The `Objects` class also simplifies implementing equals a little by pushing most
   }
 ```
 
-The first `if` statement is not logically required and could be safely omitted; it may, however, provide performance benefits. 
+The first `if` statement is not logically required and could be safely omitted; it may, however, provide performance benefits.
 
 Usually, we would recommend that such micro-optimizations are not included unless they have been proven to provide a benefit. In the case of equals methods, we suggest that the optimization is left in place. It is likely to justify itself in at least some of your classes and there is value in having all methods follow an identical template.
 
@@ -120,11 +120,11 @@ The example above uses `getClass` to check that objects are of the same type. An
 ```java
   @Override
   public boolean equals(Object obj) {
-    if (this == obj) 
+    if (this == obj)
       return true;
     if (obj == null)
       return false;
-    if (!(obj instanceof MyClass)) // <- compare with instanceof 
+    if (!(obj instanceof MyClass)) // <- compare with instanceof
       return false;
     MyClass other = (MyClass) obj;
     return Objects.equals(field1, other.field1) &&
@@ -144,7 +144,7 @@ ExtendsMyClassWithCustomEqual b = new ExtendsMyClassWithCustomEqual();
 
 a.equals(b) // true
 b.equals(a) // false, a violation of symmetry
-``` 
+```
 
 If you find yourself in a situation where you need to consider the nuances of whether subclasses are equal to their parents then we strongly suggest you reconsider your design.
 
@@ -152,7 +152,7 @@ Having to think about maintaining the equals contract in a class hierarchy is pa
 
 In the majority of cases, if you think it makes sense for your class to implement `hashCode` and `equals`, we strongly suggest you make your class final so hierarchies do not need to be considered.
 
-If you believe you have a case where it makes sense for subclasses to be treated as equivalent to their parent, use `instanceof` but ensure that the parent equals method is made final. 
+If you believe you have a case where it makes sense for subclasses to be treated as equivalent to their parent, use `instanceof` but ensure that the parent equals method is made final.
 
 Avoid relationships that are more complex than this.
 
@@ -176,7 +176,7 @@ public int hashCode() {
 
 The brevity of these implementations is attractive, but their performance is measurably poor compared to all the implementations discussed so far. If you are confident that you will not pick up real performance bottlenecks with testing and profiling then using these as initial placeholder implementations may be a reasonable approach, but in general we suggest you avoid them.
 
-### Code Generators 
+### Code Generators
 
 A number of projects exist that can auto-generate value objects at build-time. Two of the better known options are :
 
@@ -214,7 +214,7 @@ Here, Google Auto introduces some *friction* as the code shown above will not co
 
 There is also some *surprise*.
 
-Because it is a value, Animal would normally be implemented as a final class - but we have been forced to make it abstract. The team behind *Auto* recommend you add a package-private constructor to prevent other child classes being created. 
+Because it is a value, Animal would normally be implemented as a final class - but we have been forced to make it abstract. The team behind *Auto* recommend you add a package-private constructor to prevent other child classes being created.
 
 Unlike normal Java, the order in which accessors are declared is important because it is used by the generator to define the order of the constructor parameters. Re-ordering the accessors can, therefore, have the surprising effect of introducing a bug.
 
@@ -227,7 +227,7 @@ It takes a different approach to Google auto.
 Given an annotated class such as:
 
 ```java
-@Value 
+@Value
 public class ValueExample {
   String name;
   @NonFinal int age;
@@ -248,19 +248,19 @@ public final class ValueExample {
     this.age = age;
     this.score = score;
    }
-   
+
   public String getName() {
     return this.name;
   }
-   
+
   public int getAge() {
     return this.age;
   }
-   
+
   public double getScore() {
     return this.score;
   }
-   
+
   public boolean equals(Object o) {
    // valid implementation of equality based on all fields
   }

--- a/specifics/100_know_how_to_implement_hashcode_and_equals.md
+++ b/specifics/100_know_how_to_implement_hashcode_and_equals.md
@@ -174,7 +174,7 @@ public int hashCode() {
 }
 ```
 
-The brevity of these implementations is attractive, but their performance is measurably poor compared to all the implementations discussed so far. If you are confident that you will not pick up real performance bottlenecks with testing and profiling then using these as initial placeholder implementations may be a reasonable approach, but in general we suggest you avoid them.
+The brevity of these implementations is attractive, but their performance is measurably poor compared to all the implementations discussed so far. If you are confident that you will pick up real performance bottlenecks with testing and profiling then using these as initial placeholder implementations may be a reasonable approach, but in general we suggest you avoid them. 
 
 ### Code Generators
 

--- a/style/300_keep_methods_small_and_simple.md
+++ b/style/300_keep_methods_small_and_simple.md
@@ -60,16 +60,16 @@ protected static Map<String, String> getHttpHeaders(HttpServletRequest request) 
   return extractHeaders(request);
 }
 
+private static boolean isInValidHeader(HttpServletRequest request) {
+  return (request == null || request.getHeaderNames() == null);
+}
+
 private static Map<String, String> extractHeaders(HttpServletRequest request) {
   Map<String, String> httpHeaders = new HashMap<String, String>();
   for ( String name : Collections.list(request.getHeaderNames()) ) {
     httpHeaders.put(name.toLowerCase(), request.getHeader(name));
   }
   return httpHeaders;
-}
-
-private static boolean isInValidHeader(HttpServletRequest request) {
-  return (request == null || request.getHeaderNames() == null);
 }
 ```
 

--- a/style/300_keep_methods_small_and_simple.md
+++ b/style/300_keep_methods_small_and_simple.md
@@ -10,7 +10,7 @@ Small things are easier to understand than big things. Methods are no different.
 
 One way to measure the size of a method is via the number of lines of code it contains.
 
-As a guide methods should not usually be longer than 7 lines in length. This is not a hard rule - just a guide of when to feel uncomfortable with a method's size. 
+As a guide methods should not usually be longer than 7 lines in length. This is not a hard rule - just a guide of when to feel uncomfortable with a method's size.
 
 Another way to gauge the size of a method is to see how many possible paths there are through it. The *Cyclomatic complexity* of a method gives a measure of this - it will increase as the amount of conditional logic and number of loops grows.
 
@@ -21,7 +21,7 @@ Your code will naturally contain some methods that are larger than others - some
 But most large methods can be made smaller in one of three ways :
 
 * Refactoring into a number of smaller methods
-* Re-expressing the logic  
+* Re-expressing the logic
 * Using appropriate language features
 
 #### Splitting a Method into Smaller Concerns
@@ -109,10 +109,10 @@ public boolean isFnardy(String item) {
 Or with a move to a more declarative style :
 
 ```java
-private final static Set<String> FNARDY_STRINGS 
-  = ImmutableSet.of("AAA", 
-                    "ABA", 
-                    "CC", 
+private final static Set<String> FNARDY_STRINGS
+  = ImmutableSet.of("AAA",
+                    "ABA",
+                    "CC",
                     "FWR");
 
 public boolean isFnardy(String item) {
@@ -128,18 +128,18 @@ It is difficult to guess what this model might look like for our contrived examp
 
 ```java
 enum ADomainConcept {
-  AAA(true), 
-  ABA(true), 
-  CC(true), 
-  FWR(true), 
+  AAA(true),
+  ABA(true),
+  CC(true),
+  FWR(true),
   OTHER(false),
   ANDANOTHER(false);
-  
+
   private final boolean isFnardy;
   private ADomainConcept(boolean isFnardy) {
     this.isFnardy = isFnardy;
   }
-  
+
   boolean  isFnardy() {
     return isFnardy;
   }
@@ -148,7 +148,7 @@ enum ADomainConcept {
 
 #### Using Appropriate Language Features
 
-Methods are sometimes bloated by boilerplate that solves common programming problems. The need for some of this boilerplate has been removed by new language features. 
+Methods are sometimes bloated by boilerplate that solves common programming problems. The need for some of this boilerplate has been removed by new language features.
 
 Some of these *new* features aren't all that new, but code is still written without them:
 

--- a/style/40_remember_kiss_and_yagni.md
+++ b/style/40_remember_kiss_and_yagni.md
@@ -37,7 +37,7 @@ Telling accidental complexity apart from inherent complexity is of course also h
 
 Fortunately YAGNI gives us some useful advice on how to keep things simple without having to tell accidental and inherent complexity apart.
 
-The more a system does, the higher it's overall complexity will be. If we make a system that does less, it will be simpler - it will have less *inherent complexity* and less *accidental complexity*
+The more a system does, the higher its overall complexity will be. If we make a system that does less, it will be simpler - it will have less *inherent complexity* and less *accidental complexity*
 
 Your goal is, therefore, to create the minimum amount of functionality that solves the problems you have right **now**.
 

--- a/style/40_remember_kiss_and_yagni.md
+++ b/style/40_remember_kiss_and_yagni.md
@@ -2,7 +2,7 @@
 
 ### Summary
 
-Keep your design as simple as possible. 
+Keep your design as simple as possible.
 
 Create only the functionality you need now - not what you think you might need in the future.
 
@@ -10,7 +10,7 @@ Create only the functionality you need now - not what you think you might need i
 
 The KISS (Keep It Simple, Stupid) and YAGNI (You Ain't Going To Need It) acronyms provide good advice that is worth remembering while coding.
 
-KISS advises that we keep our code and designs as simple as possible.  
+KISS advises that we keep our code and designs as simple as possible.
 
 Few people would disagree with this, but unfortunately it is not always obvious what *simple* means.
 
@@ -25,15 +25,15 @@ Given two solutions to a problem which one is simpler?
 
 All of the above are reasonable definitions of *simple*. None of them is the single definition always makes sense to follow.
 
-Recognizing simple isn't easy and keeping things simple takes a lot of work. 
+Recognizing simple isn't easy and keeping things simple takes a lot of work.
 
-If we could somehow measure the complexity of our software, we would find that there is some minimum value that each piece of software must contain. 
+If we could somehow measure the complexity of our software, we would find that there is some minimum value that each piece of software must contain.
 
-If the software were any simpler, then it would be less functional. 
+If the software were any simpler, then it would be less functional.
 
-Real programs will always contain this *inherent complexity* plus a bit. This extra complexity is the *accidental complexity* we have added because we are less than perfect.  
+Real programs will always contain this *inherent complexity* plus a bit. This extra complexity is the *accidental complexity* we have added because we are less than perfect.
 
-Telling accidental complexity apart from inherent complexity is of course also hard. 
+Telling accidental complexity apart from inherent complexity is of course also hard.
 
 Fortunately YAGNI gives us some useful advice on how to keep things simple without having to tell accidental and inherent complexity apart.
 

--- a/style/600_avoid_null.md
+++ b/style/600_avoid_null.md
@@ -27,7 +27,7 @@ Strategies to avoid null include :
 
 The null object pattern is the classic OO approach to avoiding null. You should use it whenever you think you have a dependency that you think is optional.
 
-The pattern is very simple, just provide an implementation of the interface that does "nothing" or has a neutral behavior. This can then be safely referenced by it's clients, with no need to check for null.
+The pattern is very simple, just provide an implementation of the interface that does "nothing" or has a neutral behavior. This can then be safely referenced by its clients, with no need to check for null.
 
 ### Type-Safe Nulls (aka Optional)
 

--- a/style/600_avoid_null.md
+++ b/style/600_avoid_null.md
@@ -13,9 +13,9 @@ Try to limit the times you or your clients need to write the following:
 ```
 ### Details
 
-Although it is likely that libraries and frameworks you interact with will return null, you should try to ensure that this practice is isolated to third party code. 
+Although it is likely that libraries and frameworks you interact with will return null, you should try to ensure that this practice is isolated to third party code.
 
-The core of your application should assume that it does not have to worry about null values. 
+The core of your application should assume that it does not have to worry about null values.
 
 Strategies to avoid null include :
 
@@ -59,7 +59,7 @@ Static analysis rules exists that can check for code that returns null Optionals
 
 ### Design by Contract
 
-We wish for all code that we control to be able to ignore the existence of null (unless it interfaces with some third party code that forces us to consider it). 
+We wish for all code that we control to be able to ignore the existence of null (unless it interfaces with some third party code that forces us to consider it).
 
 `Objects.requireNonNull` can be used to add a runtime assertion that null has not been passed to a method.
 
@@ -67,7 +67,7 @@ Because your core code should generally assume that null will never be passed ar
 
 We can also check this contract at build time.
 
-JSR-305 provides annotations that can be used to declare where null is acceptable. 
+JSR-305 provides annotations that can be used to declare where null is acceptable.
 
 Although JSR-305 is dormant, and shows no signs of being incorporated into Java in the near future, the annotations are available at the maven co-ordinates :-
 

--- a/style/700_use_final_liberally.md
+++ b/style/700_use_final_liberally.md
@@ -14,6 +14,6 @@ For short methods, whether the benefit outweighs the cost is arguable, but if a 
 
 Each team should agree a policy for making final variables.
 
-At a minimum, everything should be made final within large method. This may also be extended to shorter methods at the team's discretion. A blanket policy has the advantage of being easy to automate/understand. A more nuanced policy is harder to communicate.
+At a minimum, everything should be made final within large methods. This may also be extended to shorter methods at the team's discretion. A blanket policy has the advantage of being easy to automate/understand. A more nuanced policy is harder to communicate.
 
 When working with legacy code, making parameters and variables final is also a useful first step in gaining understanding of the method before re-factoring. Methods that have proved difficult to express in smaller chunks will also become easier to understand when single assignment variables are final.

--- a/style/700_use_final_liberally.md
+++ b/style/700_use_final_liberally.md
@@ -2,7 +2,7 @@
 
 ### Summary
 
-Consider making final any variable or parameter that does not change. 
+Consider making final any variable or parameter that does not change.
 
 ### Details
 

--- a/style/80_make_dependencies_explicit.md
+++ b/style/80_make_dependencies_explicit.md
@@ -64,19 +64,19 @@ Here, it is clear that we must supply a `Bar` as we are unable to construct the 
 
 #### Field Annotations
 
-While annotations on fields seem convenient they mean that the dependency will not be visible in the public API. They also tie construction of your class to the frameworks that understand them and prevent fields from being made final. 
+While annotations on fields seem convenient they mean that the dependency will not be visible in the public API. They also tie construction of your class to the frameworks that understand them and prevent fields from being made final.
 
 Field annotations should not be used.
 
 If you are working with a dependency injection framework such as Spring, either move construction of your objects into configuration classes or restrict the use on annotations to constructors. Both methods allow your classes to be constructed normally and ensure that all dependencies are visible.
 
-#### Hidden Dependencies 
+#### Hidden Dependencies
 
 Anything that is not injected into a class using a constructor or as a method parameter is a hidden dependency.
 
 These are evil.
 
-They are pulled in from `Singletons`, `ThreadLocals`, static method calls or by simply calling `new`. 
+They are pulled in from `Singletons`, `ThreadLocals`, static method calls or by simply calling `new`.
 
 **Bad**
 ```java
@@ -120,7 +120,7 @@ He defines it as:
 
 > "a place where you can alter behavior in your program without editing in that place."
 
-In the original version of `HiddenDependencies`  if we wanted to replace `Database` with a mock or stub we could only do so if the singleton provided some method to modify the instance it returns. 
+In the original version of `HiddenDependencies`  if we wanted to replace `Database` with a mock or stub we could only do so if the singleton provided some method to modify the instance it returns.
 
 **Not a good approach**
 ````java

--- a/style/80_make_dependencies_explicit.md
+++ b/style/80_make_dependencies_explicit.md
@@ -4,7 +4,7 @@
 
 Make sure that the dependencies of a class are clearly visible.
 
-Always inject dependencies into a class using it's constructor. Do not use other methods such as setters or annotations on fields.
+Always inject dependencies into a class using its constructor. Do not use other methods such as setters or annotations on fields.
 
 Never introduce dependencies using hidden routes such as `Singletons` or `ThreadLocals`.
 

--- a/tests/600_understand_how_to_use_mocks_and_stubs.md
+++ b/tests/600_understand_how_to_use_mocks_and_stubs.md
@@ -34,7 +34,7 @@ We will talk about spies in a moment, but most test doubles can be conceptually 
 
 The important difference between them is that a mock has an expectation that will cause a test to fail if it is not met. i.e. if an expected method is not called on a mock the test will fail.
 
-A stub does not care if it is called or not - it's role is simply to supply values.
+A stub does not care if it is called or not - its role is simply to supply values.
 
 Traditional Mocks present a code readability dilemma. They define an expected outcome (a *then*), but are also part of the fixture required for the test to execute (a *given*).
 

--- a/tests/900_testing_FAQS.md
+++ b/tests/900_testing_FAQS.md
@@ -118,8 +118,8 @@ So first off, would your design look better if the functionality was being re-us
 
 Assuming that you can't improve your design by getting rid of the abstract class you can either:
 
-* Treat it as an implementation detail and check that each of it's clients behaves as expected.
-* Test it in isolation by creating an anonymous concrete class 
+* Treat it as an implementation detail and check that each of its clients behaves as expected.
+* Test it in isolation by creating an anonymous concrete class
 
 The first approach will result in tests that are less tied to the implementation, but there will be repetition between the tests for each subclass.
 

--- a/tests/900_testing_FAQS.md
+++ b/tests/900_testing_FAQS.md
@@ -2,13 +2,13 @@
 
 ### How Do I Test a Private Method?
 
-You don't test methods (private or public), you test the behavior of a unit as a whole. 
+You don't test methods (private or public), you test the behavior of a unit as a whole.
 
 If you cannot exercise the logic of a private method via the public interface, is that logic actually required? If it is required, and is sufficiently complex that it is causing you testing pain, then perhaps you should extract that concern into a separate unit that can be tested in isolation and injected in via the constructor?.
 
 ### How Do I Test a Void Method?
 
-You don't test methods (void or not), you test the behavior of a unit as a whole. 
+You don't test methods (void or not), you test the behavior of a unit as a whole.
 
 If the method is void, it must be performing some sort of side effect that can be checked by either state testing or interaction testing.
 
@@ -30,13 +30,13 @@ public void shouldIncreaseInSizeWhenItemsAdded() {
 
 A bad solution is to use a static method (such as joda time's `setCurrentMillisFixed`) to set the current date.
 
-A good solution is to inject a strategy for retrieving the date/time into your class as a dependency. 
+A good solution is to inject a strategy for retrieving the date/time into your class as a dependency.
 
 Java 8 provides the `java.time.Clock` class which can be used for this purpose.
 
 The static factory method `fixed` will create an instance that represents a constant time. Other methods provide implementations suitable for production use.
 
-Java 7 does not provide an out of the box class for this purpose so you will need to roll your own. 
+Java 7 does not provide an out of the box class for this purpose so you will need to roll your own.
 
 ### Do I Need to Implement a Teardown Method for my Test?
 
@@ -84,12 +84,12 @@ JUnit now provides an alternate solution in the form of the 'ExpectedException' 
 ```java
 @Rule
 public ExpectedException thrown= ExpectedException.none();
-  
+
 @Test
 public void foo() throws IOException {
   thrown.expect(FooException.class);
   thrown.expectMessage("felt like it");
-    
+
   testee.doStuff();
 }
 ```
@@ -103,7 +103,7 @@ For Java 8 AssertJ provides some custom assertions that can be used without brea
 public void testException() {
   assertThatThrownBy(() -> { testee.doStuff(); })
    .isInstanceOf(Exception.class)
-   .hasMessageContaining("felt like it"); 
+   .hasMessageContaining("felt like it");
 }
 ```
 Although it maintains the flow, the lambda in which the testee is called looks a little ugly.


### PR DESCRIPTION
Hi again, read a few more chapters this evening 👍 . These two changes are semantic differences:
5fca6c2cf03e4853722407f541b3aca78ea5c277 (Reorder code example according to logical flow)
90237faa0496af5dacbfd4dc2b0bf275fb149b87 (Semantic change: Adding a "not")

The rest are grammar and whitespace fixes (might be worth removing trailing whitespace from all files in one go?)

Let me know if you'd prefer any/all of these squashed!
Cheers
