### PR TITLE
Rename stack test to be more explicit about order

### DIFF
--- a/tests/300_name_tests_with_a_specification_style.md
+++ b/tests/300_name_tests_with_a_specification_style.md
@@ -11,7 +11,7 @@ The rest of the name should describe a behavior and, optionally, a scenario (ide
 For example, we might start to describe `java.util.Stack` with:
 
 * `shouldBeEmptyWhenCreated`
-* `shouldReturnItemsInOrderTheyWereAdded`
+* `shouldReturnMostRecentlyAddedItemsFirst`
 * `shouldThrowAnErrorWhenItemsRemovedFromEmptyStack`
 
 Contrast this with common naming patterns found in some code bases:


### PR DESCRIPTION
The method shouldReturnItemsInOrderTheyWereAdded could imply a queue instead of a stack (arguably more correctly) so reworded that test to explicitly indicate a stack behaviour