### PR TITLE
Replace suggestion to use `Throwables.propagate` with Java 7 multi-catch

### DIFF
--- a/style/900_avoid_checked_exceptions.md
+++ b/style/900_avoid_checked_exceptions.md
@@ -26,15 +26,12 @@ try {
 }
 ```
 
-If you have caught an `Exception` or a `Throwable`, so are unsure of the exact type, you can avoid creating unnecessary wrappers using Guava's `Throwables.propagate`.
+If you need to re-throw multiple checked exceptions that does not share common base other than `Exception`, to avoid unnecessary wrapping of runtime exceptions, you can use Java 7 multi-catch.
 
 ```java
 try {
-  myObject.methodThrowingException();
-} catch (Exception e) {
-  throw Throwables.propagate(e);
+  myObject.methodThrowingExceptions();
+} catch (SomeCheckedException | OtherCheckedException e) {
+  throw new RuntimeException(e);
 }
 ```
-
-This will wrap checked exceptions and re-throw unchecked exception as is.
-


### PR DESCRIPTION
Guava's `Throwables.propagate` got deprecated for good reasons: https://github.com/google/guava/wiki/Why-we-deprecated-Throwables.propagate

I'd suggest replacing suggestion to use `Throwables.propagate` with suggestion to use Java 7 multi-catch or removing mentioning usage of `Throwables.propagate` from this chapter completely.

I also do not feel good about mentioning catching of `Throwable`s in the context of handling APIs that declare checked exceptions.